### PR TITLE
Enhance robustness of filepreviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ build/Release
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
 
+# Webstorm Directory
+.idea/*
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,31 +1,48 @@
 'use strict';
 
 var request = require('request');
+var crypto = require('crypto');
 
 var API_URL = 'https://api.filepreviews.io/v1/',
+    MAX_POLLING_ATTEMPTS = 15,
+    MAX_POLLING_INTERVAL = 60000,
+    DEBUG = false,
+    S3_ACCESS_KEY,
+    S3_SECRET_KEY,
+    API_KEY,
     FilePreviews;
 
-FilePreviews = function(options) {
+
+var setup = function(options) {
   options = options || {};
 
-  this.debug = options.debug || false;
-  this.apiKey = options.apiKey;
+  DEBUG = options.debug || DEBUG;
+  API_KEY = options.apiKey || API_KEY;
+  S3_ACCESS_KEY = options.s3AccessKey || S3_ACCESS_KEY;
+  S3_SECRET_KEY = options.s3SecretKey || S3_SECRET_KEY;
 };
 
-FilePreviews.prototype.generate = function(url, options, callback) {
+
+FilePreviews = function (options) {
+  setup(options);
+};
+
+
+FilePreviews.prototype.generate = function (url, options, callback) {
   if (arguments.length === 2) {
     if (Object.prototype.toString.call(options) === '[object Function]') {
       callback = options;
     }
   }
 
-  this.submitJobToAPI(url, options, function(err, result) {
+  this.submitJobToAPI(url, options, function (err, result) {
     callback(err, result);
-    this._log('Processing done :)');
+    _log('Processing done :)');
   }.bind(this));
 };
 
-FilePreviews.prototype.submitJobToAPI = function(url, options, callback) {
+
+FilePreviews.prototype.submitJobToAPI = function (url, options, callback) {
   if (arguments.length === 2) {
     if (Object.prototype.toString.call(options) === '[object Function]') {
       callback = options;
@@ -34,31 +51,33 @@ FilePreviews.prototype.submitJobToAPI = function(url, options, callback) {
 
   var error = 'API request error: ';
 
-  this._log('API request to: ' + API_URL);
+  _log('API request to: ' + API_URL);
 
   var requestOptions = {
     url: API_URL,
-    json: this.getAPIRequestData(url, options)
+    json: _getAPIRequestData(url, options)
   };
 
-  if (this.apiKey) {
+  if (API_KEY) {
     requestOptions.headers = {
-      'X-API-Key': this.apiKey
+      'X-API-Key': API_KEY
     };
   }
 
-  request.post(requestOptions, function(err, result) {
+  request.post(requestOptions, function (err, result) {
     if (err) console.error(err);
 
     if (result.statusCode === 200 || result.statusCode === 403) {
-      this._log('Got response ' + result.statusCode);
+      _log('Got response ' + result.statusCode);
       var data = result.body;
-      this._pollForMetadata(data.metadata_url, options, function(err, metadata) {
+
+      this._pollForMetadata(data.metadata_url, options, function (err, metadata) {
         if (err) {
           callback(err);
         } else {
           callback(null, {
             metadata: metadata,
+            metadataURL: data.metadata_url,
             previewURL: data.preview_url
           });
         }
@@ -77,7 +96,8 @@ FilePreviews.prototype.submitJobToAPI = function(url, options, callback) {
   }.bind(this));
 };
 
-FilePreviews.prototype._pollForMetadata = function(url, options, callback) {
+
+FilePreviews.prototype._pollForMetadata = function (url, options, callback) {
   if (arguments.length === 2) {
     if (Object.prototype.toString.call(options) === '[object Function]') {
       callback = options;
@@ -87,13 +107,14 @@ FilePreviews.prototype._pollForMetadata = function(url, options, callback) {
   var tries = 1,
       pause = 1000;
 
-  var _getter = function() {
-    this._log('Polling for metadata, tries: ' + tries);
-    this._log('Polling url: ' + url);
+  url = _getSignedRequestUrlForMetadata(url);
+  var _getter = function () {
+    _log('Polling for metadata, tries: ' + tries);
+    _log('Polling url: ' + url);
 
-    request.get(url, function(err, result) {
+    request.get(url, function (err, result) {
       if (result.statusCode === 200) {
-        this._log('Metadata found');
+        _log('Metadata found');
         var body = JSON.parse(result.body);
         if (body.error) {
           callback(body.error, body.error);
@@ -102,9 +123,16 @@ FilePreviews.prototype._pollForMetadata = function(url, options, callback) {
         }
       } else {
         pause = pause + (tries * 1000);
+        pause = Math.min(pause, MAX_POLLING_INTERVAL);  //Never allow > 60 seconds between polling attempts.
         tries++;
 
-        this._log('Metadata not found next try in: ' + pause / 1000 + 's');
+        if (tries > MAX_POLLING_ATTEMPTS) {
+          var e = "Polling limit [" + MAX_POLLING_ATTEMPTS + " attempts] reached, cancelling pollForMetadata";
+          _log(e);
+          return callback(e);
+        }
+
+        _log('Metadata not found next try in: ' + pause / 1000 + 's');
         setTimeout(_getter, pause);
       }
     }.bind(this));
@@ -113,12 +141,63 @@ FilePreviews.prototype._pollForMetadata = function(url, options, callback) {
   return _getter();
 };
 
-FilePreviews.prototype._log = function(msg) {
-  if (this.debug) console.log(msg);
-  return this;
+
+/**
+ * Logs a message only if DEBUG is set to true
+ *
+ * @param msg
+ *
+ * @private
+ */
+var _log = function(msg) {
+  if (DEBUG) console.log(msg);
 };
 
-FilePreviews.prototype.getAPIRequestData = function(url, options) {
+/**
+ * When s3SecretKey and s3AccessKey are present, this creates a signed request to S3 to get the
+ * metadata. Unless the bucket is publically available, the request will otherwise fail.
+ *
+ * @param url
+ *
+ * @returns {String}
+ *
+ * @private
+ */
+var _getSignedRequestUrlForMetadata = function(url) {
+  if (S3_SECRET_KEY == null || S3_ACCESS_KEY == null) {
+    return url;
+  }
+
+  var regex = /(.*:\/\/.*?)\/(.*)\/(.*\/.*)/;
+
+  var matches = url.match(regex);
+  var bucket = matches[2];
+  var resource = matches[3];
+
+  var expires = Math.round((new Date().getTime()) / 1000) + 3600; //1 hour
+
+  var hmac = crypto.createHmac("sha1", S3_SECRET_KEY);
+
+  var toBeHashed = "GET\n\n\n" + expires + "\n/" + bucket + "/" + resource;
+  var hashedSignature = hmac.update(toBeHashed).digest('base64');
+  var escapedSignature = encodeURIComponent(hashedSignature);
+
+  url = url + "?AWSAccessKeyId=" + S3_ACCESS_KEY + "&Expires=" + expires + "&Signature=" + escapedSignature;
+  return url;
+};
+
+
+/**
+ * Manipulates options into format expected by FilePreviews API
+ *
+ * @param {String} url
+ * @param {Object=} options
+ *
+ * @returns {*}
+ *
+ * @private
+ */
+var _getAPIRequestData = function (url, options) {
   if (arguments.length === 1) {
     if (Object.prototype.toString.call(options) === '[object Function]') {
       options = false;
@@ -147,4 +226,7 @@ FilePreviews.prototype.getAPIRequestData = function(url, options) {
   return options;
 };
 
-module.exports = FilePreviews;
+module.exports = function(options) {
+  setup(options);
+  return FilePreviews;
+};


### PR DESCRIPTION
The primary goal of this was to enhance the robustness of this "demo" library.  Specifically, I focused on adding some module level paramaters.  This is a breaking change, meaning the module now needs to be instantiated as:

```
var FilePreviews = require('filepreviews')()
```

or you can include the "global" params on instantiation

```
var FilePreviews = require('filepreviews')({
    debug: true | false,
   apiKey: "",
   s3AccessKey: "",
   s3SecretKey: ""
 });
```

Then creating a new instance is simply

```
var filePreviews = new FilePreviews()
```

and you can reset the same options anytime when instantiating a new instance as well, just by passing in the options:

```
var filePreviews = new FilePreviews({ .... })
```

Additionally, I have added support for querying a protected non-public S3 bucket for Metadata by supplying the S3 Access and Secret Keys.  Then in the "Poll for metadata" method, a signed request is generated to use as the polling URL.  
