### PR TITLE
Add timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,23 @@ previews.generate(url, function(err, result) {
 });
 ```
 
-#### Options
-You can optinally send an options object.
+#### Construction Options
+
+You can set options that control behavior
+
+```js
+var previews = new FilePreviews({
+  debug: true,        // logs more thing, default is false
+
+  apiKey: 'ABCDEF',   // your API key from filepreviews.io
+
+  timeout: 60 * 1000  // max time to wait for metadata before erroring
+                      // if not set, will keep retrying forever
+});
+```
+
+#### Preview Options
+You can optionally send an options object.
 ```js
 var previews = new FilePreviews({debug: true});
 var options = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ FilePreviews = function(options) {
 
   this.debug = options.debug || false;
   this.apiKey = options.apiKey;
+  this.timeout = options.timeout;
 };
 
 FilePreviews.prototype.generate = function(url, options, callback) {
@@ -85,7 +86,8 @@ FilePreviews.prototype._pollForMetadata = function(url, options, callback) {
   }
 
   var tries = 1,
-      pause = 1000;
+      pause = 1000,
+      elapsed = 0;
 
   var _getter = function() {
     this._log('Polling for metadata, tries: ' + tries);
@@ -101,6 +103,11 @@ FilePreviews.prototype._pollForMetadata = function(url, options, callback) {
           callback(null, body);
         }
       } else {
+        elapsed += pause;
+        if (this.timeout && (elapsed > this.timeout)) {
+          this._log('Timeout exceeded while polling for metadata at url: ' + url);
+          return callback(new Error('Timeout exceeded while polling for metadata at url: ' + url));
+        }
         pause = pause + (tries * 1000);
         tries++;
 


### PR DESCRIPTION
Add an option 'timeout' to the constructor that, if set,
caps the metadata polling to the given value (in milliseconds).

If not set, the previous behavior (waits forever) is maintained.

Also enhance readme documentation of options slightly.
